### PR TITLE
Clean up CLI dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,8 @@ categories = ["command-line-utilities"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-structopt = "0.3.26"
+clap = { version = "4.5.41", features = ["derive"] }
 anyhow = "1.0.80"
-futures-util = "0.3.30"
-tokio = { version = "1.36.0", features = ["full"] }
-tokio-util = { version = "0.7.10", features = ["full"] }
-bytes = "1.5.0"
-futures = "0.3.30"
 rand = "0.8.5"
 hex = "0.4.3"
 tribles = { git = "https://github.com/triblespace/tribles-rust" }

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -1,13 +1,7 @@
 # Inventory
 
 ## Potential Removals
-- `futures`, `futures-util`, `tokio-util`, and `bytes` dependencies are listed in `Cargo.toml`
-  but are unused by the current source code.
-- The code base uses `structopt` which is deprecated in favour of `clap`. Migrating
-  would simplify argument parsing and remove an outdated crate.
-- The asynchronous `tokio` runtime is only used for the `#[tokio::main]` macro. If
-  no asynchronous features are added back, this dependency could be dropped.
-
+- None at the moment.
 ## Desired Functionality
 - Reintroduce commands for managing trible archives (creation, reading, writing).
 - Networking capabilities to connect to remote archives/brokers.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
+use clap::Parser;
 use rand::{rngs::OsRng, RngCore};
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 /// A knowledge graph and meta file system for object stores.
 ///
 enum TribleCli {
@@ -10,9 +10,8 @@ enum TribleCli {
     IdGen {},
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    let args = TribleCli::from_args();
+fn main() -> Result<()> {
+    let args = TribleCli::parse();
     match args {
         TribleCli::IdGen {} => {
             let mut id = [0u8; 16];


### PR DESCRIPTION
## Summary
- drop unused async crates
- migrate CLI parsing from structopt to clap
- remove tokio runtime usage
- update inventory to reflect completed cleanups

## Testing
- `cargo fmt --all`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68751986ddf48322a6725b0b35851298