### PR TITLE
Add CLI integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - Initial changelog with Let's Changelog format.
+- Integration tests for `id-gen` and `pile list-branches` commands.
 ### Changed
 - Expanded `AGENTS.md` with sections from the Tribles project and a dedicated
   inventory subsection.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ hex = "0.4.3"
 tribles = { git = "https://github.com/triblespace/tribles-rust" }
 
 [dev-dependencies]
+assert_cmd = "2.0.17"
+predicates = "3.1.3"
+tempfile = "3.20.0"
+ed25519-dalek = "2.2.0"

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -5,6 +5,7 @@
 ## Completed Work
 - Initial `list-branches` command implemented to print branch identifiers.
 - Command moved under a `pile` subcommand for extensibility.
+- Added integration tests for `id-gen` and `pile list-branches` commands.
 
 ## Desired Functionality
 - Reintroduce commands for managing trible archives (creation, reading, writing).
@@ -13,7 +14,6 @@
 - Diagnostics and repair tools similar to the old `diagnose` command.
 - Basic inspection utilities (listing entities, attributes, etc.).
 - Add support for inspecting remote object stores (S3, B2, etc.).
-- Add integration tests covering CLI commands like `idgen` and `pile list-branches`.
 - Expand crate metadata with additional tags and categories.
 
 ## Discovered Issues

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,37 @@
+use assert_cmd::Command;
+use ed25519_dalek::SigningKey;
+use predicates::prelude::*;
+use rand::rngs::OsRng;
+use tempfile::tempdir;
+use tribles::repo::{pile::Pile, Repository};
+
+#[test]
+fn idgen_outputs_id() {
+    Command::cargo_bin("trible")
+        .unwrap()
+        .arg("id-gen")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match("^[A-F0-9]{32}\n$").unwrap());
+}
+
+#[test]
+fn list_branches_outputs_branch_id() {
+    const MAX_SIZE: usize = 1 << 20; // small pile for tests
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.pile");
+
+    {
+        let pile: Pile<MAX_SIZE> = Pile::open(&path).unwrap();
+        let mut repo = Repository::new(pile, SigningKey::generate(&mut OsRng));
+        repo.branch("main").expect("create branch");
+        // drop repo to flush changes
+    }
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["pile", "list-branches", path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match("^[A-F0-9]{32}\n$").unwrap());
+}


### PR DESCRIPTION
## Summary
- add CLI integration tests for `id-gen` and `pile list-branches`
- record tests completion in the inventory
- note test addition in the changelog
- add dev dependencies needed for tests

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6877a6bc7a708322a1c6d60a4d9a2fbf