### PR TITLE
Improve pile create CLI help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Initial changelog with Let's Changelog format.
 - Integration tests for `id-gen` and `pile list-branches` commands.
+- `pile create` command to initialize new pile files.
+- Note that `touch` on Unix can also create an empty pile file.
 ### Changed
 - Expanded `AGENTS.md` with sections from the Tribles project and a dedicated
   inventory subsection.
@@ -16,3 +18,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 - Completed work entries have been trimmed from `INVENTORY.md` now that they are
   tracked here.
+- Removed completed inventory item for crate metadata expansion.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -9,7 +9,8 @@
 - Diagnostics and repair tools similar to the old `diagnose` command.
 - Basic inspection utilities (listing entities, attributes, etc.).
 - Add support for inspecting remote object stores (S3, B2, etc.).
-- Expand crate metadata with additional tags and categories.
+- Add a `pile put` command that ingests a file into a pile, creating the pile
+  if it does not already exist.
 
 ## Discovered Issues
 - `OpenError` from the `Pile` API does not implement `std::error::Error`, which

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Trible CLI
 
 A command line tool to interact with [Tribles](https://github.com/triblespace/tribles-rust).
-Currently the tool provides a simple ID generator and a `pile list-branches` command
-for inspecting local pile files. It previously contained a
+Currently the tool provides a simple `id-gen` command, `pile list-branches` for
+inspecting local pile files, and `pile create` to initialize an empty pile
+file. The latter is mostly a cross-platform convenience; on Unix-like systems a
+plain `touch` achieves the same result.
+It previously contained a
 number of experimental features (such as a broker/archiver and a notebook
 interface) which have been removed.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,14 @@ enum PileCommand {
         /// Path to the pile file to inspect
         path: PathBuf,
     },
+    /// Create a new empty pile file.
+    ///
+    /// This is mainly a cross-platform convenience; a plain `touch` on
+    /// Unix-like systems achieves the same result.
+    Create {
+        /// Path to the pile file to create
+        path: PathBuf,
+    },
 }
 
 fn main() -> Result<()> {
@@ -48,6 +56,15 @@ fn main() -> Result<()> {
                     let id = branch?;
                     println!("{id:X}");
                 }
+            }
+            PileCommand::Create { path } => {
+                use tribles::repo::pile::Pile;
+                use tribles::value::schemas::hash::Blake3;
+
+                const MAX_PILE_SIZE: usize = 1 << 30; // 1 GiB
+                let mut pile: Pile<MAX_PILE_SIZE, Blake3> =
+                    Pile::open(&path).map_err(|e| anyhow::anyhow!("{e:?}"))?;
+                pile.flush().map_err(|e| anyhow::anyhow!("{e:?}"))?;
             }
         },
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3,6 +3,7 @@ use ed25519_dalek::SigningKey;
 use predicates::prelude::*;
 use rand::rngs::OsRng;
 use tempfile::tempdir;
+use tribles::prelude::BranchStore;
 use tribles::repo::{pile::Pile, Repository};
 
 #[test]
@@ -34,4 +35,21 @@ fn list_branches_outputs_branch_id() {
         .assert()
         .success()
         .stdout(predicate::str::is_match("^[A-F0-9]{32}\n$").unwrap());
+}
+
+#[test]
+fn create_initializes_empty_pile() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("create_test.pile");
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["pile", "create", path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    const MAX_SIZE: usize = 1 << 20; // small pile for tests
+    let pile: Pile<MAX_SIZE> = Pile::open(&path).unwrap();
+    assert!(pile.branches().next().is_none());
 }


### PR DESCRIPTION
## Summary
- clarify in the `pile create` command help that a plain `touch` works on Unix

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_687bfd53e2488322aeaa995a6d8080d8