### PR TITLE
Add pile put command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Integration tests for `id-gen` and `pile list-branches` commands.
 - `pile create` command to initialize new pile files.
 - Note that `touch` on Unix can also create an empty pile file.
+- `pile put` command for ingesting a file into a pile.
+- `pile put` now memory maps the input for efficient ingestion.
 ### Changed
 - Expanded `AGENTS.md` with sections from the Tribles project and a dedicated
   inventory subsection.
 - Expanded crate metadata with additional keywords and categories.
 - Removed explanatory comment about crate metadata from `Cargo.toml`.
+- Increased default maximum pile size to 16 TiB.
+- Fixed `pile put` compilation issues when using memmap.
 ### Removed
 - Completed work entries have been trimmed from `INVENTORY.md` now that they are
   tracked here.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ anyhow = "1.0.80"
 rand = "0.8.5"
 hex = "0.4.3"
 tribles = { git = "https://github.com/triblespace/tribles-rust" }
+memmap2 = "0.9"
 
 [dev-dependencies]
 assert_cmd = "2.0.17"

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -9,8 +9,8 @@
 - Diagnostics and repair tools similar to the old `diagnose` command.
 - Basic inspection utilities (listing entities, attributes, etc.).
 - Add support for inspecting remote object stores (S3, B2, etc.).
-- Add a `pile put` command that ingests a file into a pile, creating the pile
-  if it does not already exist.
+- Incorporate new `anybytes` memory-mapping helpers once they become
+  available.
 
 ## Discovered Issues
 - `OpenError` from the `Pile` API does not implement `std::error::Error`, which


### PR DESCRIPTION
## Summary
- add `pile put` CLI subcommand to ingest files into a pile
- mmap the input file for efficient ingestion
- note fix for mmap-based ingestion in changelog
- track upcoming `anybytes` mmap helpers in the inventory

## Testing
- `cargo fmt -- --check`
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_687d7506dddc8322b833f64facfd7f2f