### PR TITLE
Simplify pile open errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Renamed `pile pull` to `pile get` to avoid confusion with repository commands.
 - Reworded inventory note about import/export commands to clarify blob
   transfers to piles and object stores via dedicated subcommands.
+- Simplified `Pile::open` error handling now that `OpenError` implements
+  `std::error::Error` upstream.
 ### Removed
 - Completed work entries have been trimmed from `INVENTORY.md` now that they are
   tracked here.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -12,6 +12,3 @@
   available.
 
 ## Discovered Issues
-- `OpenError` from the `Pile` API does not implement `std::error::Error`, which
-  makes error handling with libraries like `anyhow` cumbersome. Consider adding
-  an `Error` implementation upstream.

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,8 +69,7 @@ fn main() -> Result<()> {
                 use tribles::repo::pile::Pile;
                 use tribles::value::schemas::hash::Blake3;
 
-                let pile: Pile<DEFAULT_MAX_PILE_SIZE, Blake3> =
-                    Pile::open(&path).map_err(|e| anyhow::anyhow!("{e:?}"))?;
+                let pile: Pile<DEFAULT_MAX_PILE_SIZE, Blake3> = Pile::open(&path)?;
 
                 for branch in pile.branches() {
                     let id = branch?;
@@ -81,8 +80,7 @@ fn main() -> Result<()> {
                 use tribles::repo::pile::Pile;
                 use tribles::value::schemas::hash::Blake3;
 
-                let mut pile: Pile<DEFAULT_MAX_PILE_SIZE, Blake3> =
-                    Pile::open(&path).map_err(|e| anyhow::anyhow!("{e:?}"))?;
+                let mut pile: Pile<DEFAULT_MAX_PILE_SIZE, Blake3> = Pile::open(&path)?;
                 pile.flush().map_err(|e| anyhow::anyhow!("{e:?}"))?;
             }
             PileCommand::Put { pile, file } => {
@@ -90,12 +88,10 @@ fn main() -> Result<()> {
                 use tribles::repo::pile::Pile;
                 use tribles::value::schemas::hash::Blake3;
 
-                let mut pile: Pile<DEFAULT_MAX_PILE_SIZE, Blake3> =
-                    Pile::open(&pile).map_err(|e| anyhow::anyhow!("{e:?}"))?;
+                let mut pile: Pile<DEFAULT_MAX_PILE_SIZE, Blake3> = Pile::open(&pile)?;
                 let file_handle = File::open(&file)?;
                 let mmap = unsafe { Mmap::map(&file_handle)? };
-                pile.put::<UnknownBlob, _>(Bytes::from_source(mmap))
-                    .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+                pile.put::<UnknownBlob, _>(Bytes::from_source(mmap))?;
                 pile.flush().map_err(|e| anyhow::anyhow!("{e:?}"))?;
             }
             PileCommand::Get {
@@ -109,14 +105,13 @@ fn main() -> Result<()> {
                 use tribles::repo::pile::Pile;
                 use tribles::value::schemas::hash::{Blake3, Handle, Hash};
 
-                let mut pile: Pile<DEFAULT_MAX_PILE_SIZE, Blake3> =
-                    Pile::open(&pile).map_err(|e| anyhow::anyhow!("{e:?}"))?;
+                let mut pile: Pile<DEFAULT_MAX_PILE_SIZE, Blake3> = Pile::open(&pile)?;
                 let hash: tribles::value::Value<Hash<Blake3>> = handle
                     .try_to_value()
                     .map_err(|e| anyhow::anyhow!("{e:?}"))?;
                 let handle: tribles::value::Value<Handle<Blake3, UnknownBlob>> = hash.into();
                 let reader = pile.reader();
-                let bytes: Bytes = reader.get(handle).map_err(|e| anyhow::anyhow!("{e:?}"))?;
+                let bytes: Bytes = reader.get(handle)?;
                 let mut file = File::create(&output)?;
                 file.write_all(&bytes)?;
             }


### PR DESCRIPTION
## Summary
- streamline `Pile::open` calls since `OpenError` now implements `Error`
- update changelog
- remove outdated inventory note about `OpenError`

## Testing
- `cargo test --quiet`
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_687e605a8c6083229683fd98ae2c19bf