### PR TITLE
Implement blob listing command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `pile put` command for ingesting a file into a pile.
 - `pile put` now memory maps the input for efficient ingestion.
 - `pile get` command to extract blobs from a pile by handle.
+- `pile list-blobs` command to enumerate blob handles in a pile.
+- `pile list-blobs` output now uses built-in `Hash` formatting.
 - `pile diagnose` command to check pile integrity.
 - `pile diagnose` now verifies that all blob hashes match.
 - `pile diagnose` now exits with a nonzero code when corruption is detected.
@@ -29,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   transfers to piles and object stores via dedicated subcommands.
 - Simplified `Pile::open` error handling now that `OpenError` implements
   `std::error::Error` upstream.
+- `pile list-blobs` output uses lowercase hex instead of uppercase.
 ### Removed
 - Completed work entries have been trimmed from `INVENTORY.md` now that they are
   tracked here.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -6,6 +6,7 @@
 - Commands to put blobs into and get blobs from piles and object stores using
   their dedicated subcommands.
 - Basic inspection utilities (listing entities, attributes, etc.).
+- Initial `pile list-blobs` command lists stored blob handles.
 - Add support for inspecting remote object stores (S3, B2, etc.).
 - Incorporate new `anybytes` memory-mapping helpers once they become
   available.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 A command line tool to interact with [Tribles](https://github.com/triblespace/tribles-rust).
 Currently the tool provides a simple `id-gen` command, `pile list-branches` for
-inspecting local pile files, `pile create` to initialize an empty pile file,
-`pile put`/`get` for transferring blobs, and `pile diagnose` to verify pile
-integrity by ensuring all blobs match their hashes. The diagnose command exits
-with a nonzero code if corruption is found. It previously contained a
+inspecting local pile files, `pile list-blobs` for enumerating stored blob
+handles, `pile create` to initialize an empty pile file, `pile put`/`get` for
+transferring blobs, and `pile diagnose` to verify pile integrity by ensuring all
+blobs match their hashes. The diagnose command exits with a nonzero code if
+corruption is found. It previously contained a
 number of experimental features (such as a broker/archiver and a notebook
 interface) which have been removed.
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -122,6 +122,32 @@ fn get_restores_blob() {
 }
 
 #[test]
+fn list_blobs_outputs_handle() {
+    let dir = tempdir().unwrap();
+    let pile_path = dir.path().join("list_blobs.pile");
+    let input_path = dir.path().join("input.bin");
+    std::fs::write(&input_path, b"hello").unwrap();
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args([
+            "pile",
+            "put",
+            pile_path.to_str().unwrap(),
+            input_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["pile", "list-blobs", pile_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match("^blake3:[a-f0-9]{64}\n$").unwrap());
+}
+
+#[test]
 fn diagnose_reports_healthy() {
     let dir = tempdir().unwrap();
     let pile_path = dir.path().join("diag.pile");


### PR DESCRIPTION
## Summary
- add `pile list-blobs` command for enumerating blob handles
- output now uses `Hash::from_value` for formatting
- list output uses lowercase hex
- document new command in README
- log the new capability in CHANGELOG and INVENTORY
- test listing blob handles through the CLI

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_687ed2bf73f48322ad0dbc6afe2612e7