### PR TITLE
Organize pile subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Simplified `Pile::open` error handling now that `OpenError` implements
   `std::error::Error` upstream.
 - `pile list-blobs` output uses lowercase hex instead of uppercase.
+- Pile commands reorganized under `branch` and `blob` subcommands.
 ### Removed
 - Completed work entries have been trimmed from `INVENTORY.md` now that they are
   tracked here.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Trible CLI
 
 A command line tool to interact with [Tribles](https://github.com/triblespace/tribles-rust).
-Currently the tool provides a simple `id-gen` command, `pile list-branches` for
-inspecting local pile files, `pile list-blobs` for enumerating stored blob
-handles, `pile create` to initialize an empty pile file, `pile put`/`get` for
-transferring blobs, and `pile diagnose` to verify pile integrity by ensuring all
-blobs match their hashes. The diagnose command exits with a nonzero code if
+Currently the tool provides a simple `id-gen` command, `pile branch list` for
+inspecting local pile files, `pile blob list` for enumerating stored blob
+handles, `pile create` to initialize an empty pile file, `pile blob put`/`get`
+for transferring blobs, and `pile diagnose` to verify pile integrity by ensuring
+all blobs match their hashes. The diagnose command exits with a nonzero code if
 corruption is found. It previously contained a
 number of experimental features (such as a broker/archiver and a notebook
 interface) which have been removed.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -33,7 +33,7 @@ fn list_branches_outputs_branch_id() {
 
     Command::cargo_bin("trible")
         .unwrap()
-        .args(["pile", "list-branches", path.to_str().unwrap()])
+        .args(["pile", "branch", "list", path.to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::is_match("^[A-F0-9]{32}\n$").unwrap());
@@ -67,6 +67,7 @@ fn put_ingests_file() {
         .unwrap()
         .args([
             "pile",
+            "blob",
             "put",
             pile_path.to_str().unwrap(),
             input_path.to_str().unwrap(),
@@ -94,6 +95,7 @@ fn get_restores_blob() {
         .unwrap()
         .args([
             "pile",
+            "blob",
             "put",
             pile_path.to_str().unwrap(),
             input_path.to_str().unwrap(),
@@ -108,6 +110,7 @@ fn get_restores_blob() {
         .unwrap()
         .args([
             "pile",
+            "blob",
             "get",
             pile_path.to_str().unwrap(),
             &handle,
@@ -132,6 +135,7 @@ fn list_blobs_outputs_handle() {
         .unwrap()
         .args([
             "pile",
+            "blob",
             "put",
             pile_path.to_str().unwrap(),
             input_path.to_str().unwrap(),
@@ -141,7 +145,7 @@ fn list_blobs_outputs_handle() {
 
     Command::cargo_bin("trible")
         .unwrap()
-        .args(["pile", "list-blobs", pile_path.to_str().unwrap()])
+        .args(["pile", "blob", "list", pile_path.to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::is_match("^blake3:[a-f0-9]{64}\n$").unwrap());
@@ -181,6 +185,7 @@ fn diagnose_reports_invalid_hash() {
         .unwrap()
         .args([
             "pile",
+            "blob",
             "put",
             pile_path.to_str().unwrap(),
             blob_path.to_str().unwrap(),


### PR DESCRIPTION
## Summary
- restructure `pile` CLI to use `branch` and `blob` subcommands
- update tests for the new CLI layout
- document the new command groups
- record the change in the changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fbd2db8388322bd31db86433bf2d4