### PR TITLE
Add README command overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `pile diagnose` now verifies that all blob hashes match.
 - `pile diagnose` now exits with a nonzero code when corruption is detected.
 - Logged an inventory task to provide a structured command overview in the README.
+- Structured command overview in the README.
 ### Changed
 - Expanded `AGENTS.md` with sections from the Tribles project and a dedicated
   inventory subsection.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -10,6 +10,5 @@
 - Add support for inspecting remote object stores (S3, B2, etc.).
 - Incorporate new `anybytes` memory-mapping helpers once they become
   available.
-- Provide a structured command overview in the README.
 
 ## Discovered Issues

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # Trible CLI
 
 A command line tool to interact with [Tribles](https://github.com/triblespace/tribles-rust).
-Currently the tool provides a simple `id-gen` command, `pile branch list` for
-inspecting local pile files, `pile blob list` for enumerating stored blob
-handles, `pile create` to initialize an empty pile file, `pile blob put`/`get`
-for transferring blobs, and `pile diagnose` to verify pile integrity by ensuring
-all blobs match their hashes. The diagnose command exits with a nonzero code if
-corruption is found. It previously contained a
-number of experimental features (such as a broker/archiver and a notebook
-interface) which have been removed.
+
+## Commands
+
+- `id-gen` – generate a random identifier.
+- `pile create <PATH>` – initialize an empty pile file.
+- `pile branch list <PILE>` – list branch identifiers.
+- `pile blob list <PILE>` – list stored blob handles.
+- `pile blob put <PILE> <FILE>` – store a file as a blob.
+- `pile blob get <PILE> <HANDLE> <OUTPUT>` – extract a blob by handle.
+- `pile diagnose <PILE>` – verify pile integrity.
 
 The project now depends on the unreleased `tribles` crate directly from Git.
 


### PR DESCRIPTION
## Summary
- document CLI commands in a new README section
- remove the inventory reminder for that doc task
- record the update in CHANGELOG

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fc2a1dc3083228e452332021b05ee