### PR TITLE
Add blob inspection command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `pile put` command for ingesting a file into a pile.
 - `pile put` now memory maps the input for efficient ingestion.
 - `pile get` command to extract blobs from a pile by handle.
+- `pile blob inspect` command to show blob metadata like timestamp and size.
 - `pile list-blobs` command to enumerate blob handles in a pile.
 - `pile list-blobs` output now uses built-in `Hash` formatting.
 - `pile diagnose` command to check pile integrity.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ rand = "0.8.5"
 hex = "0.4.3"
 tribles = { git = "https://github.com/triblespace/tribles-rust" }
 memmap2 = "0.9"
+file_type = "=0.8.7"
+chrono = "0.4"
 
 [dev-dependencies]
 assert_cmd = "2.0.17"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A command line tool to interact with [Tribles](https://github.com/triblespace/tr
 - `pile blob list <PILE>` – list stored blob handles.
 - `pile blob put <PILE> <FILE>` – store a file as a blob.
 - `pile blob get <PILE> <HANDLE> <OUTPUT>` – extract a blob by handle.
+- `pile blob inspect <PILE> <HANDLE>` – display metadata for a stored blob.
 - `pile diagnose <PILE>` – verify pile integrity.
 
 The project now depends on the unreleased `tribles` crate directly from Git.


### PR DESCRIPTION
## Summary
- add `file_type` crate and `chrono` for metadata handling
- extend `pile blob inspect` to print hash, timestamp, length and guessed type
- update README and changelog
- revise CLI test for new metadata output
- rely on `PileReader::metadata` instead of manual parsing

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fcc1be95c8322aed8d6674016e1a2