### PR TITLE
Organize store subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `pile diagnose` command to check pile integrity.
 - `pile diagnose` now verifies that all blob hashes match.
 - `pile diagnose` now exits with a nonzero code when corruption is detected.
+- `store blob list` command to enumerate object store contents.
+- `store branch list` command to list branches in an object store.
 - Logged an inventory task to provide a structured command overview in the README.
 - Structured command overview in the README.
+- Renamed the future `store delete` command to `store forget` in the inventory.
 ### Changed
 - Expanded `AGENTS.md` with sections from the Tribles project and a dedicated
   inventory subsection.
@@ -35,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   `std::error::Error` upstream.
 - `pile list-blobs` output uses lowercase hex instead of uppercase.
 - Pile commands reorganized under `branch` and `blob` subcommands.
+- Store commands reorganized under `branch` and `blob` subcommands.
 ### Removed
 - Completed work entries have been trimmed from `INVENTORY.md` now that they are
   tracked here.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ tribles = { git = "https://github.com/triblespace/tribles-rust" }
 memmap2 = "0.9"
 file_type = "=0.8.7"
 chrono = "0.4"
+object_store = { version = "0.12", default-features = false, features = ["aws", "fs"] }
+tokio = { version = "1", features = ["rt"] }
+futures = "0.3"
+url = "2"
 
 [dev-dependencies]
 assert_cmd = "2.0.17"

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -7,8 +7,12 @@
   their dedicated subcommands.
 - Basic inspection utilities (listing entities, attributes, etc.).
 - Initial `pile list-blobs` command lists stored blob handles.
-- Add support for inspecting remote object stores (S3, B2, etc.).
 - Incorporate new `anybytes` memory-mapping helpers once they become
   available.
+- Add `store blob put` command to upload files to object stores.
+- Add `store blob get` command to download objects from stores.
+- Add `store blob inspect` command to print metadata for a stored object.
+- Add `store blob forget` command to remove objects from a store.
+- Add `store branch push` and `store branch pull` commands for remote branches.
 
 ## Discovered Issues

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A command line tool to interact with [Tribles](https://github.com/triblespace/tr
 - `pile blob get <PILE> <HANDLE> <OUTPUT>` – extract a blob by handle.
 - `pile blob inspect <PILE> <HANDLE>` – display metadata for a stored blob.
 - `pile diagnose <PILE>` – verify pile integrity.
+- `store blob list <URL>` – list objects at a remote store URL.
+- `store branch list <URL>` – list branches at a remote store URL.
 
 The project now depends on the unreleased `tribles` crate directly from Git.
 


### PR DESCRIPTION
## Summary
- group store commands under `blob` and `branch`
- document the new subcommands in the README
- add upcoming `store` tasks to the inventory
- adjust the CHANGELOG for the new command layout
- add integration tests for `store blob list` and `store branch list`

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688035dc6ea88322b1ed139ddaf4bc1d