### PR TITLE
Add CLI tests for branch operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `pile diagnose` now exits with a nonzero code when corruption is detected.
 - `store blob list` command to enumerate object store contents.
 - `store branch list` command to list branches in an object store.
+- `pile branch create` command to create a new branch.
+- `branch push` and `branch pull` commands to sync branches with remote stores.
+- Tests for branch creation and branch push/pull using a file object store.
 - Logged an inventory task to provide a structured command overview in the README.
 - Structured command overview in the README.
 - Renamed the future `store delete` command to `store forget` in the inventory.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ object_store = { version = "0.12", default-features = false, features = ["aws", 
 tokio = { version = "1", features = ["rt"] }
 futures = "0.3"
 url = "2"
+ed25519-dalek = "2.2.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.17"
 predicates = "3.1.3"
 tempfile = "3.20.0"
-ed25519-dalek = "2.2.0"
 blake3 = "1.8.2"

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -13,6 +13,5 @@
 - Add `store blob get` command to download objects from stores.
 - Add `store blob inspect` command to print metadata for a stored object.
 - Add `store blob forget` command to remove objects from a store.
-- Add `store branch push` and `store branch pull` commands for remote branches.
 
 ## Discovered Issues

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A command line tool to interact with [Tribles](https://github.com/triblespace/tr
 - `id-gen` – generate a random identifier.
 - `pile create <PATH>` – initialize an empty pile file.
 - `pile branch list <PILE>` – list branch identifiers.
+- `pile branch create <PILE> <NAME>` – create a new branch.
 - `pile blob list <PILE>` – list stored blob handles.
 - `pile blob put <PILE> <FILE>` – store a file as a blob.
 - `pile blob get <PILE> <HANDLE> <OUTPUT>` – extract a blob by handle.
@@ -14,6 +15,8 @@ A command line tool to interact with [Tribles](https://github.com/triblespace/tr
 - `pile diagnose <PILE>` – verify pile integrity.
 - `store blob list <URL>` – list objects at a remote store URL.
 - `store branch list <URL>` – list branches at a remote store URL.
+- `branch push <URL> <PILE> <ID>` – push a branch to a remote store.
+- `branch pull <URL> <PILE> <ID>` – pull a branch from a remote store.
 
 The project now depends on the unreleased `tribles` crate directly from Git.
 


### PR DESCRIPTION
## Summary
- test `pile branch create` command output
- verify `branch push` and `branch pull` round-trip branches with a file store
- trim completed item from inventory
- log new tests in the changelog

## Testing
- `cargo fmt`
- `cargo test` *(fails: unable to download crates)*
- `./scripts/preflight.sh` *(fails: unable to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68811dab20348322b62ee3a313db0610