### PR TITLE
Add store blob upload command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `pile diagnose` now verifies that all blob hashes match.
 - `pile diagnose` now exits with a nonzero code when corruption is detected.
 - `store blob list` command to enumerate object store contents.
+- `store blob put` command to upload files to object stores.
 - `store branch list` command to list branches in an object store.
 - `pile branch create` command to create a new branch.
 - `branch push` and `branch pull` commands to sync branches with remote stores.
@@ -42,6 +43,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `pile list-blobs` output uses lowercase hex instead of uppercase.
 - Pile commands reorganized under `branch` and `blob` subcommands.
 - Store commands reorganized under `branch` and `blob` subcommands.
+- Simplified file ingestion using `anybytes::Bytes::map_file` and removed
+  the `memmap2` dependency.
 ### Removed
 - Completed work entries have been trimmed from `INVENTORY.md` now that they are
   tracked here.
@@ -51,3 +54,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   implemented.
 - Removed inventory item for the `pile list-blobs` command now that the feature
   exists.
+- Removed inventory note about `anybytes` helper integration.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ anyhow = "1.0.80"
 rand = "0.8.5"
 hex = "0.4.3"
 tribles = { git = "https://github.com/triblespace/tribles-rust" }
-memmap2 = "0.9"
 file_type = "=0.8.7"
 chrono = "0.4"
 object_store = { version = "0.12", default-features = false, features = ["aws", "fs"] }

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -6,9 +6,6 @@
 - Commands to put blobs into and get blobs from piles and object stores using
   their dedicated subcommands.
 - Basic inspection utilities (listing entities, attributes, etc.).
-- Incorporate new `anybytes` memory-mapping helpers once they become
-  available.
-- Add `store blob put` command to upload files to object stores.
 - Add `store blob get` command to download objects from stores.
 - Add `store blob inspect` command to print metadata for a stored object.
 - Add `store blob forget` command to remove objects from a store.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A command line tool to interact with [Tribles](https://github.com/triblespace/tr
 - `pile blob inspect <PILE> <HANDLE>` – display metadata for a stored blob.
 - `pile diagnose <PILE>` – verify pile integrity.
 - `store blob list <URL>` – list objects at a remote store URL.
+- `store blob put <URL> <FILE>` – upload a file to a remote store.
 - `store branch list <URL>` – list branches at a remote store URL.
 - `branch push <URL> <PILE> <ID>` – push a branch to a remote store.
 - `branch pull <URL> <PILE> <ID>` – pull a branch from a remote store.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -265,6 +265,27 @@ fn store_blob_list_outputs_file() {
 }
 
 #[test]
+fn store_blob_put_uploads_file() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("input.bin");
+    let contents = b"hi there";
+    std::fs::write(&file_path, contents).unwrap();
+
+    let url = format!("file://{}", dir.path().display());
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["store", "blob", "put", &url, file_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    let digest = blake3::hash(contents).to_hex().to_string();
+    let blob_path = dir.path().join("blobs").join(digest);
+    assert!(blob_path.exists());
+}
+
+#[test]
 fn store_branch_list_outputs_id() {
     let dir = tempdir().unwrap();
     let branch_id = [1u8; 16];


### PR DESCRIPTION
## Summary
- add `store blob put` subcommand
- document new command in README
- record change in CHANGELOG
- remove completed inventory item
- test uploading a file to an object store
- simplify file ingestion by using `anybytes::Bytes::map_file`

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6881694b1f288322a9d6de3eba07ffd0