### PR TITLE
feat: download blobs from remote store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `pile diagnose` now exits with a nonzero code when corruption is detected.
 - `store blob list` command to enumerate object store contents.
 - `store blob put` command to upload files to object stores.
+- `store blob get` command to download blobs from object stores.
 - `store branch list` command to list branches in an object store.
 - `pile branch create` command to create a new branch.
 - `branch push` and `branch pull` commands to sync branches with remote stores.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A command line tool to interact with [Tribles](https://github.com/triblespace/tr
 - `pile diagnose <PILE>` – verify pile integrity.
 - `store blob list <URL>` – list objects at a remote store URL.
 - `store blob put <URL> <FILE>` – upload a file to a remote store.
+- `store blob get <URL> <HANDLE> <OUTPUT>` – download a blob from a remote store.
 - `store branch list <URL>` – list branches at a remote store URL.
 - `branch push <URL> <PILE> <ID>` – push a branch to a remote store.
 - `branch pull <URL> <PILE> <ID>` – pull a branch from a remote store.

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,15 @@ enum StoreBlobCommand {
         /// File whose contents should be stored remotely
         file: PathBuf,
     },
+    /// Download a blob from a remote object store.
+    Get {
+        /// URL of the source object store (e.g. "s3://bucket/path" or "file:///path")
+        url: String,
+        /// Handle of the blob to retrieve (e.g. "blake3:HEX...")
+        handle: String,
+        /// Destination file path for the downloaded blob
+        output: PathBuf,
+    },
 }
 
 fn main() -> Result<()> {
@@ -421,6 +430,29 @@ fn main() -> Result<()> {
                     let file_handle = File::open(&file)?;
                     let bytes = unsafe { Bytes::map_file(&file_handle)? };
                     remote.put::<UnknownBlob, _>(bytes)?;
+                }
+                StoreBlobCommand::Get {
+                    url,
+                    handle,
+                    output,
+                } => {
+                    use std::io::Write;
+
+                    use tribles::blob::{schemas::UnknownBlob, Bytes};
+                    use tribles::repo::objectstore::ObjectStoreRemote;
+                    use tribles::value::schemas::hash::{Blake3, Handle, Hash};
+                    use url::Url;
+
+                    let url = Url::parse(&url)?;
+                    let mut remote: ObjectStoreRemote<Blake3> = ObjectStoreRemote::with_url(&url)?;
+                    let hash: tribles::value::Value<Hash<Blake3>> = handle
+                        .try_to_value()
+                        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+                    let handle: tribles::value::Value<Handle<Blake3, UnknownBlob>> = hash.into();
+                    let reader = remote.reader();
+                    let bytes: Bytes = reader.get(handle)?;
+                    let mut file = File::create(&output)?;
+                    file.write_all(&bytes)?;
                 }
             },
             StoreCommand::Branch { cmd } => match cmd {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -286,6 +286,43 @@ fn store_blob_put_uploads_file() {
 }
 
 #[test]
+fn store_blob_get_downloads_file() {
+    let dir = tempdir().unwrap();
+    let input_path = dir.path().join("input.bin");
+    let output_path = dir.path().join("output.bin");
+    let contents = b"remote blob";
+    std::fs::write(&input_path, contents).unwrap();
+
+    let url = format!("file://{}", dir.path().display());
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["store", "blob", "put", &url, input_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let digest = blake3::hash(contents).to_hex().to_string();
+    let handle = format!("blake3:{digest}");
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args([
+            "store",
+            "blob",
+            "get",
+            &url,
+            &handle,
+            output_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    let out = std::fs::read(&output_path).unwrap();
+    assert_eq!(contents, &out[..]);
+}
+
+#[test]
 fn store_branch_list_outputs_id() {
     let dir = tempdir().unwrap();
     let branch_id = [1u8; 16];


### PR DESCRIPTION
## Summary
- support fetching blobs from remote object stores via new `store blob get` command
- test remote blob downloads against file-based object stores
- document new command in README and changelog

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688aaccbbd7083229185a4a133c1b02c