### PR TITLE
Add store blob forget command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `pile diagnose` now exits with a nonzero code when corruption is detected.
 - `store blob list` command to enumerate object store contents.
 - `store blob put` command to upload files to object stores.
+- `store blob forget` command to remove objects from object stores.
 - `store branch list` command to list branches in an object store.
 - `pile branch create` command to create a new branch.
 - `branch push` and `branch pull` commands to sync branches with remote stores.
@@ -53,5 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed inventory entry for the old `diagnose` command now that the feature is
   implemented.
 - Removed inventory item for the `pile list-blobs` command now that the feature
+  exists.
+- Removed inventory note for the `store blob forget` command now that the feature
   exists.
 - Removed inventory note about `anybytes` helper integration.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -8,6 +8,5 @@
 - Basic inspection utilities (listing entities, attributes, etc.).
 - Add `store blob get` command to download objects from stores.
 - Add `store blob inspect` command to print metadata for a stored object.
-- Add `store blob forget` command to remove objects from a store.
 
 ## Discovered Issues

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A command line tool to interact with [Tribles](https://github.com/triblespace/tr
 - `pile diagnose <PILE>` – verify pile integrity.
 - `store blob list <URL>` – list objects at a remote store URL.
 - `store blob put <URL> <FILE>` – upload a file to a remote store.
+- `store blob forget <URL> <HANDLE>` – remove an object from a remote store.
 - `store branch list <URL>` – list branches at a remote store URL.
 - `branch push <URL> <PILE> <ID>` – push a branch to a remote store.
 - `branch pull <URL> <PILE> <ID>` – pull a branch from a remote store.


### PR DESCRIPTION
## Summary
- add `store blob forget` subcommand for removing stored blobs
- document new command and note it in the changelog
- test that forgotten blobs disappear from subsequent listings

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688aace9f5708322a2cff4dc7a22cffa