### PR TITLE
Add remote blob inspect command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `pile diagnose` now exits with a nonzero code when corruption is detected.
 - `store blob list` command to enumerate object store contents.
 - `store blob put` command to upload files to object stores.
+- `store blob inspect` command to display metadata for remote blobs.
 - `store branch list` command to list branches in an object store.
 - `pile branch create` command to create a new branch.
 - `branch push` and `branch pull` commands to sync branches with remote stores.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -7,7 +7,6 @@
   their dedicated subcommands.
 - Basic inspection utilities (listing entities, attributes, etc.).
 - Add `store blob get` command to download objects from stores.
-- Add `store blob inspect` command to print metadata for a stored object.
 - Add `store blob forget` command to remove objects from a store.
 
 ## Discovered Issues

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A command line tool to interact with [Tribles](https://github.com/triblespace/tr
 - `pile diagnose <PILE>` – verify pile integrity.
 - `store blob list <URL>` – list objects at a remote store URL.
 - `store blob put <URL> <FILE>` – upload a file to a remote store.
+- `store blob inspect <URL> <HANDLE>` – display metadata for a remote blob.
 - `store branch list <URL>` – list branches at a remote store URL.
 - `branch push <URL> <PILE> <ID>` – push a branch to a remote store.
 - `branch pull <URL> <PILE> <ID>` – pull a branch from a remote store.

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,13 @@ enum StoreBlobCommand {
         /// File whose contents should be stored remotely
         file: PathBuf,
     },
+    /// Inspect a blob stored in a remote object store.
+    Inspect {
+        /// URL of the object store (e.g. "s3://bucket/path" or "file:///path")
+        url: String,
+        /// Handle of the blob to inspect (e.g. "blake3:HEX...")
+        handle: String,
+    },
 }
 
 fn main() -> Result<()> {
@@ -421,6 +428,46 @@ fn main() -> Result<()> {
                     let file_handle = File::open(&file)?;
                     let bytes = unsafe { Bytes::map_file(&file_handle)? };
                     remote.put::<UnknownBlob, _>(bytes)?;
+                }
+                StoreBlobCommand::Inspect { url, handle } => {
+                    use file_type::FileType;
+                    use futures::executor::block_on;
+                    use object_store::{parse_url, ObjectStore};
+                    use tribles::blob::{schemas::UnknownBlob, Blob};
+                    use tribles::repo::objectstore::ObjectStoreRemote;
+                    use tribles::value::schemas::hash::{Blake3, Handle, Hash};
+                    use url::Url;
+
+                    let url = Url::parse(&url)?;
+                    let mut remote: ObjectStoreRemote<Blake3> = ObjectStoreRemote::with_url(&url)?;
+                    let hash_val: tribles::value::Value<Hash<Blake3>> = handle
+                        .try_to_value()
+                        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+                    let handle_str: String = hash_val.clone().from_value();
+                    let handle_val: tribles::value::Value<Handle<Blake3, UnknownBlob>> =
+                        hash_val.into();
+                    let reader = remote.reader();
+                    let blob: Blob<UnknownBlob> = reader.get(handle_val)?;
+
+                    let (store, base) = parse_url(&url)?;
+                    let handle_hex = handle_str
+                        .split(':')
+                        .last()
+                        .ok_or_else(|| anyhow::anyhow!("invalid handle"))?;
+                    let path = base.child("blobs").child(handle_hex);
+                    let meta = block_on(async { store.head(&path).await })?;
+                    let time = meta.last_modified;
+                    let length = meta.size;
+
+                    let ftype = FileType::from_bytes(&blob.bytes);
+                    let name = ftype.name();
+
+                    println!(
+                        "Hash: {handle_str}\nTime: {}\nLength: {} bytes\nType: {}",
+                        time.to_rfc3339(),
+                        length,
+                        name
+                    );
                 }
             },
             StoreCommand::Branch { cmd } => match cmd {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -286,6 +286,32 @@ fn store_blob_put_uploads_file() {
 }
 
 #[test]
+fn store_blob_inspect_outputs_metadata() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("inspect.bin");
+    let contents = b"remote";
+    std::fs::write(&file_path, contents).unwrap();
+
+    let url = format!("file://{}", dir.path().display());
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["store", "blob", "put", &url, file_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let digest = blake3::hash(contents).to_hex().to_string();
+    let handle = format!("blake3:{digest}");
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["store", "blob", "inspect", &url, &handle])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Length:"));
+}
+
+#[test]
 fn store_branch_list_outputs_id() {
     let dir = tempdir().unwrap();
     let branch_id = [1u8; 16];


### PR DESCRIPTION
## Summary
- support inspecting remote blobs via a new `store blob inspect` command
- document the new command and note it in the changelog
- test remote blob inspection using a file-backed store

## Testing
- `cargo test`
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688aace191b08322bd1e165389434869