### PR TITLE
docs: update inventory and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Tests for branch creation and branch push/pull using a file object store.
 - Logged an inventory task to provide a structured command overview in the README.
 - Structured command overview in the README.
+- Logged inventory tasks for inspection utilities, shell completions, progress reporting, and migrating to the published `tribles` crate.
 - Renamed the future `store delete` command to `store forget` in the inventory.
 ### Changed
 - Expanded `AGENTS.md` with sections from the Tribles project and a dedicated
@@ -59,4 +60,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   exists.
 - Removed inventory note for the `store blob forget` command now that the feature
   exists.
+- Removed inventory notes for `store blob get` and `store blob inspect` now that those commands are implemented.
 - Removed inventory note about `anybytes` helper integration.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -3,11 +3,9 @@
 ## Potential Removals
 - None at the moment.
 ## Desired Functionality
-- Commands to put blobs into and get blobs from piles and object stores using
-  their dedicated subcommands.
-- Basic inspection utilities (listing entities, attributes, etc.).
-- Add `store blob get` command to download objects from stores.
-- Add `store blob inspect` command to print metadata for a stored object.
-- Add `store blob forget` command to remove objects from a store.
+- Inspection utilities for listing entities, attributes, and relations, with optional filtering.
+- Generate shell completion scripts for bash, zsh, and fish.
+- Provide progress reporting for blob transfers and other long-running operations.
+- Switch to using the published `tribles` crate on crates.io once available.
 
 ## Discovered Issues


### PR DESCRIPTION
## Summary
- trim blob command entries from `INVENTORY.md`
- log new inventory tasks for inspection utilities and CLI enhancements
- record inventory updates in the changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688b47ec9450832294a478103d2bdfb3