### PR TITLE
docs: polish README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Simplified file ingestion using `anybytes::Bytes::map_file` and removed
   the `memmap2` dependency.
 - Split CLI command groups into modules under `src/cli`.
+- Rewrote README with a friendlier tone and clarified command list.
 ### Removed
 - Completed work entries have been trimmed from `INVENTORY.md` now that they are
   tracked here.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -7,6 +7,7 @@
 - Generate shell completion scripts for bash, zsh, and fish.
 - Provide progress reporting for blob transfers and other long-running operations.
 - Switch to using the published `tribles` crate on crates.io once available.
+- Add a step-by-step quick-start example to the README.
 
 ## Discovered Issues
 - Shared code across CLI modules could be deduplicated into utilities.

--- a/README.md
+++ b/README.md
@@ -1,33 +1,63 @@
 # Trible CLI
 
-A command line tool to interact with [Tribles](https://github.com/triblespace/tribles-rust).
+Trible CLI is a friendly companion for exploring and managing
+[Tribles](https://github.com/triblespace/tribles-rust) from the command line.
 
-## Commands
+> **Note:** The project depends on the unreleased `tribles` crate directly
+> from Git.
 
-- `id-gen` – generate a random identifier.
-- `pile create <PATH>` – initialize an empty pile file.
-- `pile branch list <PILE>` – list branch identifiers.
-- `pile branch create <PILE> <NAME>` – create a new branch.
-- `pile blob list <PILE>` – list stored blob handles.
-- `pile blob put <PILE> <FILE>` – store a file as a blob.
-- `pile blob get <PILE> <HANDLE> <OUTPUT>` – extract a blob by handle.
-- `pile blob inspect <PILE> <HANDLE>` – display metadata for a stored blob.
-- `pile diagnose <PILE>` – verify pile integrity.
-- `store blob list <URL>` – list objects at a remote store URL.
-- `store blob put <URL> <FILE>` – upload a file to a remote store.
-- `store blob forget <URL> <HANDLE>` – remove an object from a remote store.
-- `store blob inspect <URL> <HANDLE>` – display metadata for a remote blob.
-- `store blob get <URL> <HANDLE> <OUTPUT>` – download a blob from a remote store.
-- `store branch list <URL>` – list branches at a remote store URL.
-- `branch push <URL> <PILE> <ID>` – push a branch to a remote store.
-- `branch pull <URL> <PILE> <ID>` – pull a branch from a remote store.
+## Installation
 
-The project now depends on the unreleased `tribles` crate directly from Git.
+```bash
+cargo install --path .
+```
+
+## Usage
+
+Run `trible <COMMAND>` to invoke a subcommand.
+
+### Generate identifiers
+
+- `id-gen` — generate a random identifier.
+
+### Work with piles
+
+- `pile create <PATH>` — initialize an empty pile.
+- `pile diagnose <PILE>` — verify pile integrity.
+
+#### Branches
+
+- `pile branch list <PILE>` — list branch identifiers.
+- `pile branch create <PILE> <NAME>` — create a new branch.
+
+#### Blobs
+
+- `pile blob list <PILE>` — list stored blob handles.
+- `pile blob put <PILE> <FILE>` — store a file as a blob.
+- `pile blob get <PILE> <HANDLE> <OUTPUT>` — extract a blob by handle.
+- `pile blob inspect <PILE> <HANDLE>` — display metadata for a stored blob.
+
+### Work with remote stores
+
+#### Blobs
+
+- `store blob list <URL>` — list objects at a remote store.
+- `store blob put <URL> <FILE>` — upload a file to a remote store.
+- `store blob get <URL> <HANDLE> <OUTPUT>` — download a blob from a remote store.
+- `store blob forget <URL> <HANDLE>` — remove an object from a remote store.
+- `store blob inspect <URL> <HANDLE>` — display metadata for a remote blob.
+
+#### Branches
+
+- `store branch list <URL>` — list branches at a remote store.
+- `branch push <URL> <PILE> <ID>` — push a branch to a remote store.
+- `branch pull <URL> <PILE> <ID>` — pull a branch from a remote store.
 
 See `INVENTORY.md` for notes on possible cleanup and future functionality.
 
 ## Development
 
-Command implementations are organized under `src/cli/` with separate modules
-for `branch`, `pile`, and `store`. The modules expose their subcommands and are
-re-exported from `main.rs` to preserve the existing CLI interface.
+Command implementations live in `src/cli/` with modules for `branch`, `pile`,
+and `store`. The modules expose their subcommands and are re-exported from
+`main.rs` to preserve the existing CLI interface. Contributions are always
+welcome!


### PR DESCRIPTION
## Summary
- reorganize command list and add installation instructions to README
- note a future quick-start example in the inventory
- record README improvements in the changelog

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688bbb9156388322b04f475b3032289c