### PR TITLE
docs: add quick-start example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Structured command overview in the README.
 - Logged inventory tasks for inspection utilities, shell completions, progress reporting, and migrating to the published `tribles` crate.
 - Renamed the future `store delete` command to `store forget` in the inventory.
+- Step-by-step quick-start example in the README.
 ### Changed
 - Expanded `AGENTS.md` with sections from the Tribles project and a dedicated
   inventory subsection.
@@ -51,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   the `memmap2` dependency.
 - Split CLI command groups into modules under `src/cli`.
 - Rewrote README with a friendlier tone and clarified command list.
+- Corrected pile file extension in README quick-start example.
 ### Removed
 - Completed work entries have been trimmed from `INVENTORY.md` now that they are
   tracked here.
@@ -65,3 +67,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed inventory notes for `store blob get` and `store blob inspect` now that those commands are implemented.
 - Removed inventory note about `anybytes` helper integration.
 - Removed stray `.orig` backup files from `src` and `tests` directories.
+- Removed inventory note for a README quick-start example now that the section exists.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -7,7 +7,6 @@
 - Generate shell completion scripts for bash, zsh, and fish.
 - Provide progress reporting for blob transfers and other long-running operations.
 - Switch to using the published `tribles` crate on crates.io once available.
-- Add a step-by-step quick-start example to the README.
 
 ## Discovered Issues
 - Shared code across CLI modules could be deduplicated into utilities.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,35 @@ Trible CLI is a friendly companion for exploring and managing
 cargo install --path .
 ```
 
+## Quick Start
+
+1. Create a new pile to hold your data:
+
+   ```bash
+   trible pile create demo.pile
+   ```
+
+2. Add a file as a blob. This command prints a handle for the stored blob:
+
+   ```bash
+   echo "hello" > greeting.txt
+   trible pile blob put demo.pile greeting.txt
+   ```
+
+3. List the blobs in the pile to confirm the handle:
+
+   ```bash
+   trible pile blob list demo.pile
+   ```
+
+4. Retrieve the blob using its handle:
+
+   ```bash
+   trible pile blob get demo.pile <HANDLE> copy.txt
+   ```
+
+The file `copy.txt` now contains the original contents of `greeting.txt`.
+
 ## Usage
 
 Run `trible <COMMAND>` to invoke a subcommand.


### PR DESCRIPTION
## Summary
- add step-by-step quick-start to README
- document change in changelog
- prune completed quick-start task from inventory
- use .pile extension in quick-start commands

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688bec095b648322a0ad06f5152fc1b9