### PR TITLE
Add CLI completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Logged inventory tasks for inspection utilities, shell completions, progress reporting, and migrating to the published `tribles` crate.
 - Renamed the future `store delete` command to `store forget` in the inventory.
 - Step-by-step quick-start example in the README.
+- `completion` command to generate shell scripts for bash, zsh, and fish.
 ### Changed
 - Expanded `AGENTS.md` with sections from the Tribles project and a dedicated
   inventory subsection.
@@ -58,6 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Completed work entries have been trimmed from `INVENTORY.md` now that they are
   tracked here.
 - Removed completed inventory item for crate metadata expansion.
+- Removed inventory note for shell completions now that the feature exists.
 - Removed note from README suggesting `touch` can create empty piles.
 - Removed inventory entry for the old `diagnose` command now that the feature is
   implemented.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ categories = [
 
 [dependencies]
 clap = { version = "4.5.41", features = ["derive"] }
+clap_complete = "4.5.55"
 anyhow = "1.0.80"
 rand = "0.8.5"
 hex = "0.4.3"

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -4,9 +4,9 @@
 - None at the moment.
 ## Desired Functionality
 - Inspection utilities for listing entities, attributes, and relations, with optional filtering.
-- Generate shell completion scripts for bash, zsh, and fish.
 - Provide progress reporting for blob transfers and other long-running operations.
 - Switch to using the published `tribles` crate on crates.io once available.
+- Offer an option for the `completion` command to write scripts directly to a file.
 
 ## Discovered Issues
 - Object store operations rely on an async runtime; consider synchronous alternatives.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Run `trible <COMMAND>` to invoke a subcommand.
 
 - `id-gen` — generate a random identifier.
 
+### Generate shell completions
+
+- `completion <SHELL>` — output a completion script for `bash`, `zsh`, or `fish`.
+
 ### Work with piles
 
 - `pile create <PATH>` — initialize an empty pile.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -20,6 +20,16 @@ fn idgen_outputs_id() {
 }
 
 #[test]
+fn completion_generates_script() {
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["completion", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("_trible()"));
+}
+
+#[test]
 fn list_branches_outputs_branch_id() {
     const MAX_SIZE: usize = 1 << 20; // small pile for tests
     let dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary
- add `completion` command to emit bash, zsh, or fish scripts
- document completion command and add integration test
- update inventory and changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d2148fa1c8322ae38e9aee3a941f0