### PR TITLE
docs: drop completion file-output inventory task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,3 +71,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed inventory note about `anybytes` helper integration.
 - Removed stray `.orig` backup files from `src` and `tests` directories.
 - Removed inventory note for a README quick-start example now that the section exists.
+- Removed inventory note about offering an option for the `completion` command to write scripts directly to a file.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -6,7 +6,6 @@
 - Inspection utilities for listing entities, attributes, and relations, with optional filtering.
 - Provide progress reporting for blob transfers and other long-running operations.
 - Switch to using the published `tribles` crate on crates.io once available.
-- Offer an option for the `completion` command to write scripts directly to a file.
 
 ## Discovered Issues
 - Object store operations rely on an async runtime; consider synchronous alternatives.


### PR DESCRIPTION
## Summary
- remove inventory task for completion command file-output option
- note removal in changelog

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688d4861530083228fae636ff58ee21e