### PR TITLE
Print blob handle after ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Rewrote README with a friendlier tone and clarified command list.
 - Corrected pile file extension in README quick-start example.
 - Deduplicated blob handle parsing across CLI modules.
+- `pile blob put` and `store blob put` now print the blob handle after
+  ingestion.
 ### Removed
 - Completed work entries have been trimmed from `INVENTORY.md` now that they are
   tracked here.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Run `trible <COMMAND>` to invoke a subcommand.
 #### Blobs
 
 - `pile blob list <PILE>` — list stored blob handles.
-- `pile blob put <PILE> <FILE>` — store a file as a blob.
+- `pile blob put <PILE> <FILE>` — store a file as a blob and print its handle.
 - `pile blob get <PILE> <HANDLE> <OUTPUT>` — extract a blob by handle.
 - `pile blob inspect <PILE> <HANDLE>` — display metadata for a stored blob.
 
@@ -75,7 +75,7 @@ Run `trible <COMMAND>` to invoke a subcommand.
 #### Blobs
 
 - `store blob list <URL>` — list objects at a remote store.
-- `store blob put <URL> <FILE>` — upload a file to a remote store.
+- `store blob put <URL> <FILE>` — upload a file to a remote store and print its handle.
 - `store blob get <URL> <HANDLE> <OUTPUT>` — download a blob from a remote store.
 - `store blob forget <URL> <HANDLE>` — remove an object from a remote store.
 - `store blob inspect <URL> <HANDLE>` — display metadata for a remote blob.

--- a/src/cli/pile.rs
+++ b/src/cli/pile.rs
@@ -126,12 +126,15 @@ pub fn run(cmd: PileCommand) -> Result<()> {
             BlobCommand::Put { pile, file } => {
                 use tribles::blob::{schemas::UnknownBlob, Bytes};
                 use tribles::repo::pile::Pile;
-                use tribles::value::schemas::hash::Blake3;
+                use tribles::value::schemas::hash::{Blake3, Handle, Hash};
 
                 let mut pile: Pile<DEFAULT_MAX_PILE_SIZE, Blake3> = Pile::open(&pile)?;
                 let file_handle = File::open(&file)?;
                 let bytes = unsafe { Bytes::map_file(&file_handle)? };
-                pile.put::<UnknownBlob, _>(bytes)?;
+                let handle = pile.put::<UnknownBlob, _>(bytes)?;
+                let hash: tribles::value::Value<Hash<Blake3>> = Handle::to_hash(handle);
+                let string: String = hash.from_value();
+                println!("{}", string);
                 pile.flush().map_err(|e| anyhow::anyhow!("{e:?}"))?;
             }
             BlobCommand::Get {

--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -90,14 +90,17 @@ pub fn run(cmd: StoreCommand) -> Result<()> {
             StoreBlobCommand::Put { url, file } => {
                 use tribles::blob::{schemas::UnknownBlob, Bytes};
                 use tribles::repo::objectstore::ObjectStoreRemote;
-                use tribles::value::schemas::hash::Blake3;
+                use tribles::value::schemas::hash::{Blake3, Handle, Hash};
                 use url::Url;
 
                 let url = Url::parse(&url)?;
                 let mut remote: ObjectStoreRemote<Blake3> = ObjectStoreRemote::with_url(&url)?;
                 let file_handle = File::open(&file)?;
                 let bytes = unsafe { Bytes::map_file(&file_handle)? };
-                remote.put::<UnknownBlob, _>(bytes)?;
+                let handle = remote.put::<UnknownBlob, _>(bytes)?;
+                let hash: tribles::value::Value<Hash<Blake3>> = Handle::to_hash(handle);
+                let string: String = hash.from_value();
+                println!("{}", string);
             }
             StoreBlobCommand::Get {
                 url,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -74,6 +74,10 @@ fn put_ingests_file() {
     let input_path = dir.path().join("input.bin");
     std::fs::write(&input_path, b"hello world").unwrap();
 
+    let digest = blake3::hash(b"hello world").to_hex().to_string();
+    let handle = format!("blake3:{digest}");
+    let pattern = format!("^{}\\n$", handle);
+
     Command::cargo_bin("trible")
         .unwrap()
         .args([
@@ -85,7 +89,7 @@ fn put_ingests_file() {
         ])
         .assert()
         .success()
-        .stdout(predicate::str::is_empty());
+        .stdout(predicate::str::is_match(pattern).unwrap());
 
     const MAX_SIZE: usize = 1 << 20; // small pile for tests
     let mut pile: Pile<MAX_SIZE> = Pile::open(&pile_path).unwrap();
@@ -283,14 +287,17 @@ fn store_blob_put_uploads_file() {
 
     let url = format!("file://{}", dir.path().display());
 
+    let digest = blake3::hash(contents).to_hex().to_string();
+    let handle = format!("blake3:{digest}");
+    let pattern = format!("^{}\\n$", handle);
+
     Command::cargo_bin("trible")
         .unwrap()
         .args(["store", "blob", "put", &url, file_path.to_str().unwrap()])
         .assert()
         .success()
-        .stdout(predicate::str::is_empty());
+        .stdout(predicate::str::is_match(&pattern).unwrap());
 
-    let digest = blake3::hash(contents).to_hex().to_string();
     let blob_path = dir.path().join("blobs").join(digest);
     assert!(blob_path.exists());
 }
@@ -304,14 +311,16 @@ fn store_blob_forget_removes_blob() {
 
     let url = format!("file://{}", dir.path().display());
 
+    let digest = blake3::hash(contents).to_hex().to_string();
+    let handle = format!("blake3:{digest}");
+    let pattern = format!("^{}\\n$", handle);
+
     Command::cargo_bin("trible")
         .unwrap()
         .args(["store", "blob", "put", &url, file_path.to_str().unwrap()])
         .assert()
-        .success();
-
-    let digest = blake3::hash(contents).to_hex().to_string();
-    let handle = format!("blake3:{digest}");
+        .success()
+        .stdout(predicate::str::is_match(&pattern).unwrap());
 
     Command::cargo_bin("trible")
         .unwrap()
@@ -373,14 +382,16 @@ fn store_blob_inspect_outputs_metadata() {
 
     let url = format!("file://{}", dir.path().display());
 
+    let digest = blake3::hash(contents).to_hex().to_string();
+    let handle = format!("blake3:{digest}");
+    let pattern = format!("^{}\\n$", handle);
+
     Command::cargo_bin("trible")
         .unwrap()
         .args(["store", "blob", "put", &url, file_path.to_str().unwrap()])
         .assert()
-        .success();
-
-    let digest = blake3::hash(contents).to_hex().to_string();
-    let handle = format!("blake3:{digest}");
+        .success()
+        .stdout(predicate::str::is_match(&pattern).unwrap());
 
     Command::cargo_bin("trible")
         .unwrap()


### PR DESCRIPTION
## Summary
- print blob handle for local and remote blob ingestion
- document handle output and cover it in CLI tests

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e0e4198dc832285c59924609f8753