### PR TITLE
Refactor CLI integration tests into modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Deduplicated blob handle parsing across CLI modules.
 - `pile blob put` and `store blob put` now print the blob handle after
   ingestion.
+- Split CLI integration tests into smaller modules for readability.
 ### Removed
 - Completed work entries have been trimmed from `INVENTORY.md` now that they are
   tracked here.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -9,4 +9,4 @@
 
 ## Discovered Issues
 - Object store operations rely on an async runtime; consider synchronous alternatives.
-- CLI integration tests live in a single large file; consider splitting them into modules for readability.
+- Preflight script and test suite take an unusually long time to run; investigate ways to reduce build and execution time.

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,0 +1,22 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn genid_outputs_id() {
+    Command::cargo_bin("trible")
+        .unwrap()
+        .arg("genid")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match("^[A-F0-9]{32}\\n$").unwrap());
+}
+
+#[test]
+fn completion_generates_script() {
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["completion", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("_trible()"));
+}

--- a/tests/pile.rs
+++ b/tests/pile.rs
@@ -1,33 +1,12 @@
 use assert_cmd::Command;
 use blake3;
 use ed25519_dalek::SigningKey;
-use hex;
 use predicates::prelude::*;
 use rand::rngs::OsRng;
 use tempfile::tempdir;
 use tribles::prelude::BranchStore;
 use tribles::prelude::{BlobStore, BlobStoreList};
 use tribles::repo::{pile::Pile, Repository};
-
-#[test]
-fn genid_outputs_id() {
-    Command::cargo_bin("trible")
-        .unwrap()
-        .arg("genid")
-        .assert()
-        .success()
-        .stdout(predicate::str::is_match("^[A-F0-9]{32}\n$").unwrap());
-}
-
-#[test]
-fn completion_generates_script() {
-    Command::cargo_bin("trible")
-        .unwrap()
-        .args(["completion", "bash"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("_trible()"));
-}
 
 #[test]
 fn list_branches_outputs_branch_id() {
@@ -47,7 +26,7 @@ fn list_branches_outputs_branch_id() {
         .args(["pile", "branch", "list", path.to_str().unwrap()])
         .assert()
         .success()
-        .stdout(predicate::str::is_match("^[A-F0-9]{32}\n$").unwrap());
+        .stdout(predicate::str::is_match("^[A-F0-9]{32}\\n$").unwrap());
 }
 
 #[test]
@@ -163,7 +142,7 @@ fn list_blobs_outputs_handle() {
         .args(["pile", "blob", "list", pile_path.to_str().unwrap()])
         .assert()
         .success()
-        .stdout(predicate::str::is_match("^blake3:[a-f0-9]{64}\n$").unwrap());
+        .stdout(predicate::str::is_match("^blake3:[a-f0-9]{64}\\n$").unwrap());
 }
 
 #[test]
@@ -263,164 +242,6 @@ fn inspect_outputs_tribles() {
 }
 
 #[test]
-fn store_blob_list_outputs_file() {
-    let dir = tempdir().unwrap();
-    let file = dir.path().join("file.bin");
-    std::fs::write(&file, b"hi").unwrap();
-
-    let url = format!("file://{}", dir.path().display());
-
-    Command::cargo_bin("trible")
-        .unwrap()
-        .args(["store", "blob", "list", &url])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("file.bin"));
-}
-
-#[test]
-fn store_blob_put_uploads_file() {
-    let dir = tempdir().unwrap();
-    let file_path = dir.path().join("input.bin");
-    let contents = b"hi there";
-    std::fs::write(&file_path, contents).unwrap();
-
-    let url = format!("file://{}", dir.path().display());
-
-    let digest = blake3::hash(contents).to_hex().to_string();
-    let handle = format!("blake3:{digest}");
-    let pattern = format!("^{}\\n$", handle);
-
-    Command::cargo_bin("trible")
-        .unwrap()
-        .args(["store", "blob", "put", &url, file_path.to_str().unwrap()])
-        .assert()
-        .success()
-        .stdout(predicate::str::is_match(&pattern).unwrap());
-
-    let blob_path = dir.path().join("blobs").join(digest);
-    assert!(blob_path.exists());
-}
-
-#[test]
-fn store_blob_forget_removes_blob() {
-    let dir = tempdir().unwrap();
-    let file_path = dir.path().join("input.bin");
-    let contents = b"remove me";
-    std::fs::write(&file_path, contents).unwrap();
-
-    let url = format!("file://{}", dir.path().display());
-
-    let digest = blake3::hash(contents).to_hex().to_string();
-    let handle = format!("blake3:{digest}");
-    let pattern = format!("^{}\\n$", handle);
-
-    Command::cargo_bin("trible")
-        .unwrap()
-        .args(["store", "blob", "put", &url, file_path.to_str().unwrap()])
-        .assert()
-        .success()
-        .stdout(predicate::str::is_match(&pattern).unwrap());
-
-    Command::cargo_bin("trible")
-        .unwrap()
-        .args(["store", "blob", "forget", &url, &handle])
-        .assert()
-        .success();
-
-    Command::cargo_bin("trible")
-        .unwrap()
-        .args(["store", "blob", "list", &url])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(&digest).not());
-}
-
-#[test]
-fn store_blob_get_downloads_file() {
-    let dir = tempdir().unwrap();
-    let input_path = dir.path().join("input.bin");
-    let output_path = dir.path().join("output.bin");
-    let contents = b"remote blob";
-    std::fs::write(&input_path, contents).unwrap();
-
-    let url = format!("file://{}", dir.path().display());
-
-    Command::cargo_bin("trible")
-        .unwrap()
-        .args(["store", "blob", "put", &url, input_path.to_str().unwrap()])
-        .assert()
-        .success();
-
-    let digest = blake3::hash(contents).to_hex().to_string();
-    let handle = format!("blake3:{digest}");
-
-    Command::cargo_bin("trible")
-        .unwrap()
-        .args([
-            "store",
-            "blob",
-            "get",
-            &url,
-            &handle,
-            output_path.to_str().unwrap(),
-        ])
-        .assert()
-        .success()
-        .stdout(predicate::str::is_empty());
-
-    let out = std::fs::read(&output_path).unwrap();
-    assert_eq!(contents, &out[..]);
-}
-
-#[test]
-fn store_blob_inspect_outputs_metadata() {
-    let dir = tempdir().unwrap();
-    let file_path = dir.path().join("inspect.bin");
-    let contents = b"remote";
-    std::fs::write(&file_path, contents).unwrap();
-
-    let url = format!("file://{}", dir.path().display());
-
-    let digest = blake3::hash(contents).to_hex().to_string();
-    let handle = format!("blake3:{digest}");
-    let pattern = format!("^{}\\n$", handle);
-
-    Command::cargo_bin("trible")
-        .unwrap()
-        .args(["store", "blob", "put", &url, file_path.to_str().unwrap()])
-        .assert()
-        .success()
-        .stdout(predicate::str::is_match(&pattern).unwrap());
-
-    Command::cargo_bin("trible")
-        .unwrap()
-        .args(["store", "blob", "inspect", &url, &handle])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("Length:"));
-}
-
-#[test]
-fn store_branch_list_outputs_id() {
-    let dir = tempdir().unwrap();
-    let branch_id = [1u8; 16];
-    let branch_hex = hex::encode(branch_id);
-    let branches_dir = dir.path().join("branches");
-    std::fs::create_dir_all(&branches_dir).unwrap();
-    std::fs::write(branches_dir.join(&branch_hex), b"branch").unwrap();
-
-    let url = format!("file://{}", dir.path().display());
-
-    Command::cargo_bin("trible")
-        .unwrap()
-        .args(["store", "branch", "list", &url])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(branch_hex.to_ascii_uppercase()));
-}
-
-#[test]
 fn pile_branch_create_outputs_id() {
     let dir = tempdir().unwrap();
     let pile_path = dir.path().join("create_branch.pile");
@@ -436,51 +257,12 @@ fn pile_branch_create_outputs_id() {
         ])
         .assert()
         .success()
-        .stdout(predicate::str::is_match("^[A-F0-9]{32}\n$").unwrap());
+        .stdout(predicate::str::is_match("^[A-F0-9]{32}\\n$").unwrap());
 
     Command::cargo_bin("trible")
         .unwrap()
         .args(["pile", "branch", "list", pile_path.to_str().unwrap()])
         .assert()
         .success()
-        .stdout(predicate::str::is_match("^[A-F0-9]{32}\n$").unwrap());
-}
-
-#[test]
-fn branch_push_pull_transfers_branch() {
-    const MAX_SIZE: usize = 1 << 20;
-    let dir = tempdir().unwrap();
-    let local = dir.path().join("local.pile");
-    let remote_dir = dir.path().join("remote");
-    std::fs::create_dir_all(remote_dir.join("branches")).unwrap();
-    std::fs::create_dir_all(remote_dir.join("blobs")).unwrap();
-    let url = format!("file://{}", remote_dir.display());
-
-    let branch_id = {
-        let pile: Pile<MAX_SIZE> = Pile::open(&local).unwrap();
-        let mut repo = Repository::new(pile, SigningKey::generate(&mut OsRng));
-        let ws = repo.branch("main").unwrap();
-        ws.branch_id()
-    };
-    let branch_hex = hex::encode(branch_id);
-
-    Command::cargo_bin("trible")
-        .unwrap()
-        .args(["branch", "push", &url, local.to_str().unwrap(), &branch_hex])
-        .assert()
-        .success();
-
-    let other = dir.path().join("other.pile");
-    Command::cargo_bin("trible")
-        .unwrap()
-        .args(["branch", "pull", &url, other.to_str().unwrap(), &branch_hex])
-        .assert()
-        .success();
-
-    Command::cargo_bin("trible")
-        .unwrap()
-        .args(["pile", "branch", "list", other.to_str().unwrap()])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(branch_hex.to_ascii_uppercase()));
+        .stdout(predicate::str::is_match("^[A-F0-9]{32}\\n$").unwrap());
 }

--- a/tests/store.rs
+++ b/tests/store.rs
@@ -1,0 +1,206 @@
+use assert_cmd::Command;
+use blake3;
+use ed25519_dalek::SigningKey;
+use hex;
+use predicates::prelude::*;
+use rand::rngs::OsRng;
+use tempfile::tempdir;
+use tribles::prelude::BranchStore;
+use tribles::repo::{pile::Pile, Repository};
+
+#[test]
+fn store_blob_list_outputs_file() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("file.bin");
+    std::fs::write(&file, b"hi").unwrap();
+
+    let url = format!("file://{}", dir.path().display());
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["store", "blob", "list", &url])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("file.bin"));
+}
+
+#[test]
+fn store_blob_put_uploads_file() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("input.bin");
+    let contents = b"hi there";
+    std::fs::write(&file_path, contents).unwrap();
+
+    let url = format!("file://{}", dir.path().display());
+
+    let digest = blake3::hash(contents).to_hex().to_string();
+    let handle = format!("blake3:{digest}");
+    let pattern = format!("^{}\\n$", handle);
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["store", "blob", "put", &url, file_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(&pattern).unwrap());
+
+    let blob_path = dir.path().join("blobs").join(digest);
+    assert!(blob_path.exists());
+}
+
+#[test]
+fn store_blob_forget_removes_blob() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("input.bin");
+    let contents = b"remove me";
+    std::fs::write(&file_path, contents).unwrap();
+
+    let url = format!("file://{}", dir.path().display());
+
+    let digest = blake3::hash(contents).to_hex().to_string();
+    let handle = format!("blake3:{digest}");
+    let pattern = format!("^{}\\n$", handle);
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["store", "blob", "put", &url, file_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(&pattern).unwrap());
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["store", "blob", "forget", &url, &handle])
+        .assert()
+        .success();
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["store", "blob", "list", &url])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&digest).not());
+}
+
+#[test]
+fn store_blob_get_downloads_file() {
+    let dir = tempdir().unwrap();
+    let input_path = dir.path().join("input.bin");
+    let output_path = dir.path().join("output.bin");
+    let contents = b"remote blob";
+    std::fs::write(&input_path, contents).unwrap();
+
+    let url = format!("file://{}", dir.path().display());
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["store", "blob", "put", &url, input_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let digest = blake3::hash(contents).to_hex().to_string();
+    let handle = format!("blake3:{digest}");
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args([
+            "store",
+            "blob",
+            "get",
+            &url,
+            &handle,
+            output_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    let out = std::fs::read(&output_path).unwrap();
+    assert_eq!(contents, &out[..]);
+}
+
+#[test]
+fn store_blob_inspect_outputs_metadata() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("inspect.bin");
+    let contents = b"remote";
+    std::fs::write(&file_path, contents).unwrap();
+
+    let url = format!("file://{}", dir.path().display());
+
+    let digest = blake3::hash(contents).to_hex().to_string();
+    let handle = format!("blake3:{digest}");
+    let pattern = format!("^{}\\n$", handle);
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["store", "blob", "put", &url, file_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(&pattern).unwrap());
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["store", "blob", "inspect", &url, &handle])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Length:"));
+}
+
+#[test]
+fn store_branch_list_outputs_id() {
+    let dir = tempdir().unwrap();
+    let branch_id = [1u8; 16];
+    let branch_hex = hex::encode(branch_id);
+    let branches_dir = dir.path().join("branches");
+    std::fs::create_dir_all(&branches_dir).unwrap();
+    std::fs::write(branches_dir.join(&branch_hex), b"branch").unwrap();
+
+    let url = format!("file://{}", dir.path().display());
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["store", "branch", "list", &url])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(branch_hex.to_ascii_uppercase()));
+}
+
+#[test]
+fn branch_push_pull_transfers_branch() {
+    const MAX_SIZE: usize = 1 << 20;
+    let dir = tempdir().unwrap();
+    let local = dir.path().join("local.pile");
+    let remote_dir = dir.path().join("remote");
+    std::fs::create_dir_all(remote_dir.join("branches")).unwrap();
+    std::fs::create_dir_all(remote_dir.join("blobs")).unwrap();
+    let url = format!("file://{}", remote_dir.display());
+
+    let branch_id = {
+        let pile: Pile<MAX_SIZE> = Pile::open(&local).unwrap();
+        let mut repo = Repository::new(pile, SigningKey::generate(&mut OsRng));
+        let ws = repo.branch("main").unwrap();
+        ws.branch_id()
+    };
+    let branch_hex = hex::encode(branch_id);
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["branch", "push", &url, local.to_str().unwrap(), &branch_hex])
+        .assert()
+        .success();
+
+    let other = dir.path().join("other.pile");
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["branch", "pull", &url, other.to_str().unwrap(), &branch_hex])
+        .assert()
+        .success();
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["pile", "branch", "list", other.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(branch_hex.to_ascii_uppercase()));
+}


### PR DESCRIPTION
## Summary
- split monolithic CLI integration tests into basic, pile, and store modules
- document slow preflight/test runs in inventory
- note test restructuring in changelog

## Testing
- `cargo fmt`
- `cargo test --test basic` *(hangs compiling `file_type v0.8.7`)*
- `./scripts/preflight.sh` *(hangs compiling `file_type v0.8.7`)*

------
https://chatgpt.com/codex/tasks/task_e_688e152a471483228887880f5ee83415