### PR TITLE
Ensure `pile create` creates parent directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `pile blob put` and `store blob put` now print the blob handle after
   ingestion.
 - Split CLI integration tests into smaller modules for readability.
+- `pile create` now creates parent directories if they do not exist.
 ### Removed
 - Completed work entries have been trimmed from `INVENTORY.md` now that they are
   tracked here.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -6,6 +6,7 @@
 - Inspection utilities for listing entities, attributes, and relations, with optional filtering.
 - Provide progress reporting for blob transfers and other long-running operations.
 - Switch to using the published `tribles` crate on crates.io once available.
+- Allow specifying a custom maximum pile size when creating piles.
 
 ## Discovered Issues
 - Object store operations rely on an async runtime; consider synchronous alternatives.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Run `trible <COMMAND>` to invoke a subcommand.
 
 ### Work with piles
 
-- `pile create <PATH>` — initialize an empty pile.
+- `pile create <PATH>` — initialize an empty pile, creating parent directories as needed.
 - `pile diagnose <PILE>` — verify pile integrity.
 
 #### Branches

--- a/src/cli/pile.rs
+++ b/src/cli/pile.rs
@@ -192,8 +192,13 @@ pub fn run(cmd: PileCommand) -> Result<()> {
             }
         },
         PileCommand::Create { path } => {
+            use std::fs;
             use tribles::repo::pile::Pile;
             use tribles::value::schemas::hash::Blake3;
+
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
 
             let mut pile: Pile<DEFAULT_MAX_PILE_SIZE, Blake3> = Pile::open(&path)?;
             pile.flush().map_err(|e| anyhow::anyhow!("{e:?}"))?;

--- a/tests/pile.rs
+++ b/tests/pile.rs
@@ -47,6 +47,25 @@ fn create_initializes_empty_pile() {
 }
 
 #[test]
+fn create_creates_parent_directories() {
+    let dir = tempdir().unwrap();
+    let path = dir
+        .path()
+        .join("nested")
+        .join("dirs")
+        .join("create_test.pile");
+
+    Command::cargo_bin("trible")
+        .unwrap()
+        .args(["pile", "create", path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(path.exists());
+    assert!(path.parent().unwrap().exists());
+}
+
+#[test]
 fn put_ingests_file() {
     let dir = tempdir().unwrap();
     let pile_path = dir.path().join("put_test.pile");


### PR DESCRIPTION
## Summary
- Create parent directories before initializing a new pile file.
- Test nested pile creation and document behavior.
- Note future work for customizable pile sizes.

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e24e782688322b7b66f2f77d619ce