### PR TITLE
test: verify pile blob list outputs exact handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Renamed the future `store delete` command to `store forget` in the inventory.
 - Step-by-step quick-start example in the README.
 - `completion` command to generate shell scripts for bash, zsh, and fish.
+- Test ensuring `pile blob list` outputs the exact handle for ingested blobs.
 ### Changed
 - Renamed `id-gen` command to `genid` to align with the GenID schema.
 - Expanded `AGENTS.md` with sections from the Tribles project and a dedicated

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -7,6 +7,7 @@
 - Provide progress reporting for blob transfers and other long-running operations.
 - Switch to using the published `tribles` crate on crates.io once available.
 - Allow specifying a custom maximum pile size when creating piles.
+- Enhance `pile blob list` with optional filtering and metadata output.
 
 ## Discovered Issues
 - Object store operations rely on an async runtime; consider synchronous alternatives.

--- a/tests/pile.rs
+++ b/tests/pile.rs
@@ -138,11 +138,16 @@ fn get_restores_blob() {
 }
 
 #[test]
-fn list_blobs_outputs_handle() {
+fn list_blobs_outputs_expected_handle() {
     let dir = tempdir().unwrap();
     let pile_path = dir.path().join("list_blobs.pile");
     let input_path = dir.path().join("input.bin");
-    std::fs::write(&input_path, b"hello").unwrap();
+    let contents = b"hello";
+    std::fs::write(&input_path, contents).unwrap();
+
+    let digest = blake3::hash(contents).to_hex().to_string();
+    let handle = format!("blake3:{digest}");
+    let pattern = format!("^{}\\n$", handle);
 
     Command::cargo_bin("trible")
         .unwrap()
@@ -161,7 +166,7 @@ fn list_blobs_outputs_handle() {
         .args(["pile", "blob", "list", pile_path.to_str().unwrap()])
         .assert()
         .success()
-        .stdout(predicate::str::is_match("^blake3:[a-f0-9]{64}\\n$").unwrap());
+        .stdout(predicate::str::is_match(&pattern).unwrap());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- tighten `pile blob list` integration test to expect the precise handle
- document the new test in the changelog
- note future improvements for `pile blob list` filtering/metadata in the inventory

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e284310788322a2cf9c1dea52e87d