### PR TITLE
chore: remove pile blob filter inventory item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,3 +79,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed stray `.orig` backup files from `src` and `tests` directories.
 - Removed inventory note for a README quick-start example now that the section exists.
 - Removed inventory note about offering an option for the `completion` command to write scripts directly to a file.
+- Removed inventory entry for enhancing `pile blob list` with optional filtering.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -7,7 +7,6 @@
 - Provide progress reporting for blob transfers and other long-running operations.
 - Switch to using the published `tribles` crate on crates.io once available.
 - Allow specifying a custom maximum pile size when creating piles.
-- Enhance `pile blob list` with optional filtering.
 
 ## Discovered Issues
 - Object store operations rely on an async runtime; consider synchronous alternatives.


### PR DESCRIPTION
## Summary
- remove inventory note for adding optional filtering to `pile blob list`
- log inventory cleanup in the changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688f6e33951083229cc39ff2c06227a5