### PR TITLE
Align CLI with latest tribles crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   ingestion.
 - Split CLI integration tests into smaller modules for readability.
 - `pile create` now creates parent directories if they do not exist.
+- Updated to latest `tribles` crate and imported required store traits.
 ### Removed
 - Completed work entries have been trimmed from `INVENTORY.md` now that they are
   tracked here.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -13,3 +13,4 @@
 ## Discovered Issues
 - Object store operations rely on an async runtime; consider synchronous alternatives.
 - Preflight script and test suite take an unusually long time to run; investigate ways to reduce build and execution time.
+- Address remaining compiler warnings from unused imports and variables.

--- a/src/cli/pile/blob.rs
+++ b/src/cli/pile/blob.rs
@@ -51,6 +51,7 @@ pub fn run(cmd: Command) -> Result<()> {
             use std::time::UNIX_EPOCH;
 
             use tribles::blob::schemas::UnknownBlob;
+            use tribles::prelude::BlobStore;
             use tribles::prelude::BlobStoreList;
             use tribles::repo::pile::Pile;
             use tribles::value::schemas::hash::Blake3;
@@ -103,6 +104,7 @@ pub fn run(cmd: Command) -> Result<()> {
 
             use tribles::blob::schemas::UnknownBlob;
             use tribles::blob::Bytes;
+            use tribles::prelude::BlobStore;
             use tribles::prelude::BlobStoreGet;
             use tribles::repo::pile::Pile;
             use tribles::value::schemas::hash::Blake3;
@@ -125,6 +127,7 @@ pub fn run(cmd: Command) -> Result<()> {
 
             use tribles::blob::schemas::UnknownBlob;
             use tribles::blob::Blob;
+            use tribles::prelude::BlobStore;
             use tribles::prelude::BlobStoreGet;
             use tribles::repo::pile::BlobMetadata;
             use tribles::repo::pile::Pile;

--- a/src/cli/pile/branch.rs
+++ b/src/cli/pile/branch.rs
@@ -6,6 +6,8 @@ use std::path::PathBuf;
 
 use crate::DEFAULT_MAX_PILE_SIZE;
 
+use tribles::prelude::{BlobStore, BlobStoreGet, BranchStore};
+
 #[derive(Parser)]
 pub enum Command {
     /// List all branch identifiers in a pile file.

--- a/src/cli/pile/mod.rs
+++ b/src/cli/pile/mod.rs
@@ -5,6 +5,8 @@ use std::path::PathBuf;
 
 use crate::DEFAULT_MAX_PILE_SIZE;
 
+use tribles::prelude::{BlobStore, BlobStoreGet, BranchStore};
+
 pub mod blob;
 pub mod branch;
 
@@ -247,9 +249,10 @@ pub fn run(cmd: PileCommand) -> Result<()> {
                         anyhow::bail!("diagnostics reported issues");
                     }
                 }
-                Err(OpenError::Missing) => {
+                Err(OpenError::IoError(err)) if err.kind() == std::io::ErrorKind::NotFound => {
                     anyhow::bail!("pile not found");
                 }
+                Err(e) => return Err(e.into()),
             }
             Ok(())
         }

--- a/src/cli/store/blob.rs
+++ b/src/cli/store/blob.rs
@@ -95,6 +95,7 @@ pub fn run(cmd: Command) -> Result<()> {
 
             use tribles::blob::schemas::UnknownBlob;
             use tribles::blob::Bytes;
+            use tribles::prelude::BlobStore;
             use tribles::prelude::BlobStoreGet;
             use tribles::repo::objectstore::ObjectStoreRemote;
             use tribles::value::schemas::hash::Blake3;
@@ -118,6 +119,7 @@ pub fn run(cmd: Command) -> Result<()> {
             use object_store::ObjectStore;
             use tribles::blob::schemas::UnknownBlob;
             use tribles::blob::Blob;
+            use tribles::prelude::BlobStore;
             use tribles::prelude::BlobStoreGet;
             use tribles::repo::objectstore::ObjectStoreRemote;
             use tribles::value::schemas::hash::Blake3;

--- a/src/cli/store/branch.rs
+++ b/src/cli/store/branch.rs
@@ -13,6 +13,7 @@ pub enum Command {
 pub fn run(cmd: Command) -> Result<()> {
     match cmd {
         Command::List { url } => {
+            use tribles::prelude::BranchStore;
             use tribles::repo::objectstore::ObjectStoreRemote;
             use tribles::value::schemas::hash::Blake3;
             use url::Url;


### PR DESCRIPTION
## Summary
- update to current `tribles` dependency
- import required store traits across CLI modules
- adapt pile diagnostics to new `OpenError` API

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a7a2a4a70c832289cfc334e83500f0